### PR TITLE
chore: override default value of config when map[string]string

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -53,6 +53,38 @@ func Load() {
 	// Load flags
 	parseFlags()
 
+	m := make(map[string]interface{})
+
+	for _, v := range entries {
+
+		switch v.Value.(type) {
+
+		case map[string]string:
+			toString, err := f.GetStringToString(v.Key)
+			if err != nil {
+				log.Println(err)
+			}
+			m[v.Key] = toString
+		case map[string]int:
+			toString, err := f.GetStringToInt(v.Key)
+			if err != nil {
+				log.Println(err)
+			}
+			m[v.Key] = toString
+		case map[string]int64:
+			toString, err := f.GetStringToInt64(v.Key)
+			if err != nil {
+				log.Println(err)
+			}
+			m[v.Key] = toString
+		}
+
+	}
+
+	if err := instance.Load(confmap.Provider(m, "."), nil); err != nil {
+		panic(err)
+	}
+
 	var files []string
 
 	confEnv := os.Getenv(ConfEnvironment)
@@ -95,38 +127,6 @@ func Load() {
 	flap := posflag.Provider(f, ".", instance)
 
 	if err := instance.Load(flap, nil); err != nil {
-		panic(err)
-	}
-
-	m := make(map[string]interface{})
-
-	for _, v := range entries {
-
-		switch v.Value.(type) {
-
-		case map[string]string:
-			toString, err := f.GetStringToString(v.Key)
-			if err != nil {
-				log.Println(err)
-			}
-			m[v.Key] = toString
-		case map[string]int:
-			toString, err := f.GetStringToInt(v.Key)
-			if err != nil {
-				log.Println(err)
-			}
-			m[v.Key] = toString
-		case map[string]int64:
-			toString, err := f.GetStringToInt64(v.Key)
-			if err != nil {
-				log.Println(err)
-			}
-			m[v.Key] = toString
-		}
-
-	}
-
-	if err := instance.Load(confmap.Provider(m, "."), nil); err != nil {
 		panic(err)
 	}
 

--- a/loader_test.go
+++ b/loader_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		key         string
+		value       interface{}
+		description string
+		gotFunc     func(string) interface{}
+		expected    interface{}
+	}{
+		{
+			key:         "def",
+			value:       map[string]string{"a": "A"},
+			description: "test map string string",
+			gotFunc: func(key string) interface{} {
+				return StringMap(key)
+			},
+			expected: map[string]string{"a": "A"},
+		},
+		{
+			key:         "def",
+			value:       "test",
+			description: "test",
+			gotFunc: func(key string) interface{} {
+				return String(key)
+			},
+			expected: "test",
+		},
+		{
+			key:         "red",
+			value:       map[string]string{"h": "0.0.0.0"},
+			description: "overriding default",
+			gotFunc: func(key string) interface{} {
+				return StringMap("red")
+			},
+			expected: map[string]string{"h": "127.0.0.14"},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			flagLoad()
+			os.Args = []string{"--conf", "./testdata/config.yaml"}
+			entries = []Config{}
+			Add(tt.key, tt.value, tt.description)
+			Load()
+			got := tt.gotFunc(tt.key)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("expected %v got %v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, when reading a value from an entry, the default overwrites the value that was defined in a file. Example:

```go
// content of config.yaml:
//
//   def:
//    h: content of file
os.Args = []string{"--conf", "./config.yaml"}

config.Add("def", map[string]string{}, "test");

config.Load()

fmt.Println(config.StringMap("def"))

// Prints: map[]
// Expected: map[h:content of file]
```
I understand that the correct thing would be to assume the default value if the key value is not defined.
